### PR TITLE
Dev add maybe needs error msg check

### DIFF
--- a/clang-tools-extra/clang-tidy/maybe/CMakeLists.txt
+++ b/clang-tools-extra/clang-tidy/maybe/CMakeLists.txt
@@ -8,6 +8,7 @@ add_clang_library(clangTidyMaybeModule
   MaybeTidyModule.cpp
   UnusedCheck.cpp
   UseSafeMethodsCheck.cpp
+  NeedErrorMsgCheck.cpp
 
   LINK_LIBS
   clangTidy

--- a/clang-tools-extra/clang-tidy/maybe/MaybeTidyModule.cpp
+++ b/clang-tools-extra/clang-tidy/maybe/MaybeTidyModule.cpp
@@ -10,6 +10,7 @@
 #include "../ClangTidyModule.h"
 #include "../ClangTidyModuleRegistry.h"
 #include "GlogFatalCheck.h"
+#include "NeedErrorMsgCheck.h"
 #include "UnusedCheck.h"
 #include "UseSafeMethodsCheck.h"
 
@@ -20,12 +21,10 @@ namespace maybe {
 class MaybeModule : public ClangTidyModule {
 public:
   void addCheckFactories(ClangTidyCheckFactories &CheckFactories) override {
-    CheckFactories.registerCheck<GlogFatalCheck>(
-        "maybe-glog-fatal");
-    CheckFactories.registerCheck<UnusedCheck>(
-        "maybe-unused");
-    CheckFactories.registerCheck<UseSafeMethodsCheck>(
-        "maybe-use-safe-methods");
+    CheckFactories.registerCheck<GlogFatalCheck>("maybe-glog-fatal");
+    CheckFactories.registerCheck<UnusedCheck>("maybe-unused");
+    CheckFactories.registerCheck<UseSafeMethodsCheck>("maybe-use-safe-methods");
+    CheckFactories.registerCheck<NeedErrorMsgCheck>("maybe-need-error-msg");
   }
 };
 
@@ -41,4 +40,3 @@ volatile int MaybeModuleAnchorSource = 0;
 
 } // namespace tidy
 } // namespace clang
-

--- a/clang-tools-extra/clang-tidy/maybe/NeedErrorMsgCheck.cpp
+++ b/clang-tools-extra/clang-tidy/maybe/NeedErrorMsgCheck.cpp
@@ -1,0 +1,95 @@
+//===--- NeedErrorMsgCheck.cpp - clang-tidy
+//----------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "NeedErrorMsgCheck.h"
+#include "CommonMatcher.h"
+#include "clang/AST/ASTContext.h"
+#include "clang/AST/Decl.h"
+#include "clang/AST/Expr.h"
+#include "clang/AST/ExprCXX.h"
+#include "clang/ASTMatchers/ASTMatchFinder.h"
+#include "clang/ASTMatchers/ASTMatchers.h"
+#include "clang/Basic/SourceLocation.h"
+#include "clang/Lex/Lexer.h"
+#include "llvm/ADT/SmallVector.h"
+
+#include <iostream>
+
+using namespace clang::ast_matchers;
+
+namespace clang {
+namespace tidy {
+namespace maybe {
+
+void NeedErrorMsgCheck::registerMatchers(MatchFinder *Finder) {
+  Finder->addMatcher(returnStmt(forFunction(functionDecl(returns(
+                                    matchesNameForType("^Maybe<.*>$")))))
+                         .bind("returnStmt"),
+                     this);
+}
+
+void NeedErrorMsgCheck::check(const MatchFinder::MatchResult &Result) {
+  const ReturnStmt *Matched = Result.Nodes.getNodeAs<ReturnStmt>("returnStmt");
+  // getExpansionRange returns a empty range if the code at the loc is not a
+  // macro
+  auto ExpansionRange =
+      Result.SourceManager->getExpansionRange(Matched->getBeginLoc());
+  auto SourceTxt = Lexer::getSourceText(ExpansionRange, *Result.SourceManager,
+                                        getLangOpts());
+
+  llvm::SmallVector<const CXXOperatorCallExpr *> callExprs;
+  auto AddCallExpr = [&callExprs](const ArrayRef<BoundNodes> Matches) {
+    for (const auto &Match : Matches) {
+      const auto *Operator = Match.getNodeAs<CXXOperatorCallExpr>("operator<<");
+      if (Operator) {
+        callExprs.push_back(Operator);
+      }
+    }
+  };
+
+  auto CallExprMatcher =
+      cxxOperatorCallExpr(
+          hasOverloadedOperatorName("<<"),
+          hasArgument(1, unless(callExpr(callee(functionDecl(
+                             returns(asString("class oneflow::Error"))))))))
+          .bind("operator<<");
+
+  AddCallExpr(
+      match(traverse(TK_IgnoreUnlessSpelledInSource, findAll(CallExprMatcher)),
+            *Matched, *(Result.Context)));
+
+  // Check macro names and the minimum number of serialization (operator <<)
+  // among them
+  llvm::StringMap<unsigned> CheckMacroNamesAndSerializeCount{
+      {"CHECK_OR_RETURN", 3},    {"CHECK_EQ_OR_RETURN", 8},
+      {"CHECK_LT_OR_RETURN", 8}, {"CHECK_LE_OR_RETURN", 8},
+      {"CHECK_NE_OR_RETURN", 8}, {"CHECK_GE_OR_RETURN", 8},
+      {"CHECK_GT_OR_RETURN", 8}, {"CHECK_NOTNULL_OR_RETURN", 3}};
+
+  // Match statement "return Error::RuntimeError();" if serializeCount is 0
+  unsigned serializeCount = 0;
+  for (const auto &KV : CheckMacroNamesAndSerializeCount) {
+    const auto &Name = KV.getKey().str();
+    if (SourceTxt.startswith(Name + "(")) {
+      serializeCount = KV.getValue();
+      break;
+    }
+  }
+  if (callExprs.size() > serializeCount) {
+    return;
+  }
+  diag(Matched->getBeginLoc(),
+       "This function maybe return error but without any error message, please "
+       "specify an error message.")
+      << Matched->getSourceRange();
+}
+
+} // namespace maybe
+} // namespace tidy
+} // namespace clang

--- a/clang-tools-extra/clang-tidy/maybe/NeedErrorMsgCheck.h
+++ b/clang-tools-extra/clang-tidy/maybe/NeedErrorMsgCheck.h
@@ -1,0 +1,34 @@
+//===--- NeedErrorMsgCheck.h - clang-tidy ---------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_MAYBE_NEEDERRORMSGCHECK_H
+#define LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_MAYBE_NEEDERRORMSGCHECK_H
+
+#include "../ClangTidyCheck.h"
+
+namespace clang {
+namespace tidy {
+namespace maybe {
+
+/// FIXME: Write a short description.
+///
+/// For the user-facing documentation see:
+/// http://clang.llvm.org/extra/clang-tidy/checks/maybe-glog-fatal.html
+class NeedErrorMsgCheck : public ClangTidyCheck {
+public:
+  NeedErrorMsgCheck(StringRef Name, ClangTidyContext *Context)
+      : ClangTidyCheck(Name, Context) {}
+  void registerMatchers(ast_matchers::MatchFinder *Finder) override;
+  void check(const ast_matchers::MatchFinder::MatchResult &Result) override;
+};
+
+} // namespace maybe
+} // namespace tidy
+} // namespace clang
+
+#endif // LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_MAYBE_NEEDERRORMSGCHECK_H

--- a/clang-tools-extra/clang-tidy/maybe/NeedErrorMsgCheck.h
+++ b/clang-tools-extra/clang-tidy/maybe/NeedErrorMsgCheck.h
@@ -16,9 +16,6 @@ namespace tidy {
 namespace maybe {
 
 /// FIXME: Write a short description.
-///
-/// For the user-facing documentation see:
-/// http://clang.llvm.org/extra/clang-tidy/checks/maybe-glog-fatal.html
 class NeedErrorMsgCheck : public ClangTidyCheck {
 public:
   NeedErrorMsgCheck(StringRef Name, ClangTidyContext *Context)


### PR DESCRIPTION
对于下面的测试代码，应用maybe-need-error-msg检查，
```c++
#include "oneflow/core/common/maybe.h"

using namespace oneflow;

Maybe<int> f() {
  CHECK_OR_RETURN(1);  // no error message
  CHECK_OR_RETURN(1) << "";
  CHECK_OR_RETURN(1) << Error::RuntimeError();  // no error message
  CHECK_OR_RETURN(1) << Error::RuntimeError() << "";
  CHECK_OR_RETURN(1) << "" << Error::RuntimeError();

  CHECK_GT_OR_RETURN(1, 0);  // no error message
  CHECK_GT_OR_RETURN(1, 0) << "";
  CHECK_GT_OR_RETURN(1, 0) << Error::RuntimeError();  // no error message
  CHECK_GT_OR_RETURN(1, 0) << Error::RuntimeError() << "";

  CHECK_NOTNULL_OR_RETURN(0);  // no error message
  CHECK_NOTNULL_OR_RETURN(0) << "";

  return Error::RuntimeError();  // no error message

  return 1;
}

Maybe<int> g() {
  JUST(f());
  return f();
}

int main() {
  f();
  return 0;
}
```

检查的结果为，
```shell
6 warnings generated.
/home/hjchen2/Project/oneflow/oneflow/core/common/clang_tidy_test.cpp:6:3: warning: This function maybe return error but without any error message, please specify an error message. [maybe-need-error-msg]
  CHECK_OR_RETURN(1);
  ^
/home/hjchen2/Project/oneflow/oneflow/core/common/clang_tidy_test.cpp:8:3: warning: This function maybe return error but without any error message, please specify an error message. [maybe-need-error-msg]
  CHECK_OR_RETURN(1) << Error::RuntimeError();
  ^
/home/hjchen2/Project/oneflow/oneflow/core/common/clang_tidy_test.cpp:12:3: warning: This function maybe return error but without any error message, please specify an error message. [maybe-need-error-msg]
  CHECK_GT_OR_RETURN(1, 0);
  ^
/home/hjchen2/Project/oneflow/oneflow/core/common/clang_tidy_test.cpp:14:3: warning: This function maybe return error but without any error message, please specify an error message. [maybe-need-error-msg]
  CHECK_GT_OR_RETURN(1, 0) << Error::RuntimeError();
  ^
/home/hjchen2/Project/oneflow/oneflow/core/common/clang_tidy_test.cpp:17:3: warning: This function maybe return error but without any error message, please specify an error message. [maybe-need-error-msg]
  CHECK_NOTNULL_OR_RETURN(0);
  ^
/home/hjchen2/Project/oneflow/oneflow/core/common/clang_tidy_test.cpp:20:3: warning: This function maybe return error but without any error message, please specify an error message. [maybe-need-error-msg]
  return Error::RuntimeError();
  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
```